### PR TITLE
Updating invoke-snowsql to not create files with utf8bom

### DIFF
--- a/SnowSQL/public/Invoke-SnowSql.ps1
+++ b/SnowSQL/public/Invoke-SnowSql.ps1
@@ -84,7 +84,9 @@ function Invoke-SnowSql
         {
             $Path = New-TemporaryFile
             Write-Verbose "Saving query to file [$Path]"
-            $Query | Set-Content -Path $Path -Encoding UTF8
+
+            #Setting to UTF8 without BOM as snowsql commands for files with BOM fail
+            [System.IO.File]::WriteAllLines($Path, $Query)
         }
 
         $snowSqlParam = @(


### PR DESCRIPTION
In the event there are queries longer than 500 characters Invoke-SnowSQL will create a temporary file.  However it is creating the temporary file in UTF-8BOM which snowsql throws the following error:

syntax error line 1 at position 0 unexpected '\ufeffB'.

Using the following command encodes it properly